### PR TITLE
refactor: bump standard-tags to v0.3.0

### DIFF
--- a/modules/mgmt/prometheus-server/README.md
+++ b/modules/mgmt/prometheus-server/README.md
@@ -21,7 +21,7 @@
 | <a name="module_asg"></a> [asg](#module\_asg) | terraform-aws-modules/autoscaling/aws | 6.5.3 |
 | <a name="module_asg_iam_policy"></a> [asg\_iam\_policy](#module\_asg\_iam\_policy) | terraform-aws-modules/iam/aws//modules/iam-policy | 5.11.2 |
 | <a name="module_asg_security_group"></a> [asg\_security\_group](#module\_asg\_security\_group) | terraform-aws-modules/security-group/aws | 4.16.2 |
-| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.1.1 |
+| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.3.0 |
 
 ## Resources
 

--- a/modules/mgmt/prometheus-server/main.tf
+++ b/modules/mgmt/prometheus-server/main.tf
@@ -14,11 +14,11 @@ locals {
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.1.1"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = local.service_name
   owner       = "infra"
+  service     = local.service_name
 }
 
 # ------------------------------------------------------------------------------

--- a/modules/mgmt/semaphore-ec2/README.md
+++ b/modules/mgmt/semaphore-ec2/README.md
@@ -28,7 +28,7 @@
 | <a name="module_load_balancer"></a> [load\_balancer](#module\_load\_balancer) | terraform-aws-modules/alb/aws | 8.2.1 |
 | <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds/aws | 5.2.3 |
 | <a name="module_rds_security_group"></a> [rds\_security\_group](#module\_rds\_security\_group) | terraform-aws-modules/security-group/aws | 4.16.2 |
-| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.2.0 |
+| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.3.0 |
 
 ## Resources
 

--- a/modules/mgmt/semaphore-ec2/main.tf
+++ b/modules/mgmt/semaphore-ec2/main.tf
@@ -19,11 +19,11 @@ locals {
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.2.0"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = local.service_name
   owner       = "infra"
+  service     = local.service_name
 }
 
 # ------------------------------------------------------------------------------

--- a/modules/mgmt/semaphore-ecs/README.md
+++ b/modules/mgmt/semaphore-ecs/README.md
@@ -29,7 +29,7 @@
 | <a name="module_load_balancer"></a> [load\_balancer](#module\_load\_balancer) | terraform-aws-modules/alb/aws | 8.2.1 |
 | <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds/aws | 5.2.3 |
 | <a name="module_rds_security_group"></a> [rds\_security\_group](#module\_rds\_security\_group) | terraform-aws-modules/security-group/aws | 4.16.2 |
-| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.2.0 |
+| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.3.0 |
 
 ## Resources
 

--- a/modules/mgmt/semaphore-ecs/main.tf
+++ b/modules/mgmt/semaphore-ecs/main.tf
@@ -22,11 +22,11 @@ locals {
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.2.0"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = local.service_name
   owner       = "infra"
+  service     = local.service_name
 }
 
 # ------------------------------------------------------------------------------

--- a/modules/mgmt/semaphore-trigger/README.md
+++ b/modules/mgmt/semaphore-trigger/README.md
@@ -20,7 +20,7 @@ No providers.
 | <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | 4.7.1 |
 | <a name="module_lambda_security_group"></a> [lambda\_security\_group](#module\_lambda\_security\_group) | terraform-aws-modules/security-group/aws | 4.16.2 |
 | <a name="module_sqs_queue"></a> [sqs\_queue](#module\_sqs\_queue) | terraform-aws-modules/sqs/aws | 4.0.0 |
-| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.1.1 |
+| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.3.0 |
 
 ## Resources
 

--- a/modules/mgmt/semaphore-trigger/main.tf
+++ b/modules/mgmt/semaphore-trigger/main.tf
@@ -14,11 +14,11 @@ locals {
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.1.1"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = local.service_name
   owner       = "infra"
+  service     = local.service_name
 }
 
 # ------------------------------------------------------------------------------

--- a/modules/networking/route53-zone/README.md
+++ b/modules/networking/route53-zone/README.md
@@ -18,7 +18,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.1.1 |
+| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.3.0 |
 
 ## Resources
 

--- a/modules/networking/route53-zone/main.tf
+++ b/modules/networking/route53-zone/main.tf
@@ -4,11 +4,11 @@
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.1.1"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = "core-infra"
   owner       = "infra"
+  service     = "core-infra"
 }
 
 # ------------------------------------------------------------------------------

--- a/modules/networking/security-groups/README.md
+++ b/modules/networking/security-groups/README.md
@@ -30,7 +30,7 @@ No providers.
 | <a name="module_infra_services_security_group"></a> [infra\_services\_security\_group](#module\_infra\_services\_security\_group) | terraform-aws-modules/security-group/aws | 4.17.1 |
 | <a name="module_prometheus_server_security_group"></a> [prometheus\_server\_security\_group](#module\_prometheus\_server\_security\_group) | terraform-aws-modules/security-group/aws | 4.17.1 |
 | <a name="module_semaphore_server_security_group"></a> [semaphore\_server\_security\_group](#module\_semaphore\_server\_security\_group) | terraform-aws-modules/security-group/aws | 4.17.1 |
-| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.2.0 |
+| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.3.0 |
 
 ## Resources
 

--- a/modules/networking/security-groups/main.tf
+++ b/modules/networking/security-groups/main.tf
@@ -4,11 +4,11 @@
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.2.0"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = "core-infra"
   owner       = "infra"
+  service     = "core-infra"
 }
 
 # ------------------------------------------------------------------------------

--- a/modules/networking/vpc/README.md
+++ b/modules/networking/vpc/README.md
@@ -18,7 +18,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.1.1 |
+| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.3.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.19.0 |
 
 ## Resources

--- a/modules/networking/vpc/main.tf
+++ b/modules/networking/vpc/main.tf
@@ -46,11 +46,11 @@ locals {
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.1.1"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = "core-infra"
   owner       = "infra"
+  service     = "core-infra"
 }
 
 # ------------------------------------------------------------------------------

--- a/modules/networking/wireguard-server/README.md
+++ b/modules/networking/wireguard-server/README.md
@@ -59,7 +59,7 @@ To fix it, follow the steps below:
 | <a name="module_ec2_security_group"></a> [ec2\_security\_group](#module\_ec2\_security\_group) | terraform-aws-modules/security-group/aws | 4.16.2 |
 | <a name="module_smtp_iam_policy"></a> [smtp\_iam\_policy](#module\_smtp\_iam\_policy) | terraform-aws-modules/iam/aws//modules/iam-policy | 5.9.2 |
 | <a name="module_smtp_iam_user"></a> [smtp\_iam\_user](#module\_smtp\_iam\_user) | terraform-aws-modules/iam/aws//modules/iam-user | 5.10.0 |
-| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.1.1 |
+| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.3.0 |
 
 ## Resources
 

--- a/modules/networking/wireguard-server/main.tf
+++ b/modules/networking/wireguard-server/main.tf
@@ -12,11 +12,11 @@ locals {
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.1.1"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = local.service_name
   owner       = "infra"
+  service     = local.service_name
 }
 
 # ------------------------------------------------------------------------------

--- a/modules/services/nomad-cluster/README.md
+++ b/modules/services/nomad-cluster/README.md
@@ -21,7 +21,7 @@
 | <a name="module_client_instances"></a> [client\_instances](#module\_client\_instances) | ./modules/instances | n/a |
 | <a name="module_intra_security_group"></a> [intra\_security\_group](#module\_intra\_security\_group) | terraform-aws-modules/security-group/aws | 4.16.2 |
 | <a name="module_server_instances"></a> [server\_instances](#module\_server\_instances) | ./modules/instances | n/a |
-| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.2.0 |
+| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.3.0 |
 
 ## Resources
 

--- a/modules/services/nomad-cluster/main.tf
+++ b/modules/services/nomad-cluster/main.tf
@@ -12,11 +12,11 @@ locals {
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.2.0"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = local.service_name
   owner       = var.owner
+  service     = local.service_name
 }
 
 # ------------------------------------------------------------------------------

--- a/modules/services/nomad-cluster/modules/instances/main.tf
+++ b/modules/services/nomad-cluster/modules/instances/main.tf
@@ -4,11 +4,11 @@
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.2.0"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = var.service_name
   owner       = var.owner
+  service     = var.service_name
 }
 
 # ------------------------------------------------------------------------------

--- a/modules/services/wordpress-site/README.md
+++ b/modules/services/wordpress-site/README.md
@@ -30,7 +30,7 @@
 | <a name="module_memcached_security_group"></a> [memcached\_security\_group](#module\_memcached\_security\_group) | terraform-aws-modules/security-group/aws | 4.16.2 |
 | <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds/aws | 5.2.3 |
 | <a name="module_rds_security_group"></a> [rds\_security\_group](#module\_rds\_security\_group) | terraform-aws-modules/security-group/aws | 4.16.2 |
-| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.1.1 |
+| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.3.0 |
 
 ## Resources
 

--- a/modules/services/wordpress-site/main.tf
+++ b/modules/services/wordpress-site/main.tf
@@ -18,11 +18,11 @@ locals {
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.1.1"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = var.site_name
   owner       = var.owner
+  service     = var.site_name
 }
 
 # ------------------------------------------------------------------------------

--- a/modules/storage/s3-bucket/README.md
+++ b/modules/storage/s3-bucket/README.md
@@ -17,7 +17,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | 3.7.0 |
-| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.2.0 |
+| <a name="module_tags"></a> [tags](#module\_tags) | flaudisio/standard-tags/aws | 0.3.0 |
 
 ## Resources
 

--- a/modules/storage/s3-bucket/main.tf
+++ b/modules/storage/s3-bucket/main.tf
@@ -4,11 +4,11 @@
 
 module "tags" {
   source  = "flaudisio/standard-tags/aws"
-  version = "0.2.0"
+  version = "0.3.0"
 
   environment = var.environment
-  service     = var.service
   owner       = var.owner
+  service     = var.service
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This update rename the `service` tag to `service-name` (see flaudisio/terraform-aws-standard-tags#2).